### PR TITLE
Add current sig-release-leads to repo admins

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -3,3 +3,4 @@
 approvers:
   - tallclair
   - kubernetes/enhancements-admins
+  - sig-release-leads

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -6,3 +6,8 @@ aliases:
     - mrbobbytables
     - johnbelamaric
     - jeremyrickard
+  sig-release-leads:
+    - alejandrox1
+    - justaugustus
+    - saschagrunert
+    - tpepper


### PR DESCRIPTION
The main consumers of this repository will be k/release and
k/test-infra, which means that we can also add the sig-release-leads as
owners.