### PR TITLE
Add inline code support

### DIFF
--- a/mdtoc_test.go
+++ b/mdtoc_test.go
@@ -71,6 +71,11 @@ var testcases = []testcase{{
 	includePrefix: false,
 	completeTOC:   true,
 	validTOCTags:  true,
+}, {
+	file:          testdata("code.md"),
+	includePrefix: true,
+	completeTOC:   true,
+	validTOCTags:  true,
 }}
 
 func testdata(subpath string) string {

--- a/pkg/mdtoc/mdtoc.go
+++ b/pkg/mdtoc/mdtoc.go
@@ -137,18 +137,17 @@ func findTOCTags(raw []byte) (start, end int) {
 	return
 }
 
-func asText(node ast.Node) string {
-	var text string
+func asText(node ast.Node) (text string) {
 	ast.WalkFunc(node, func(node ast.Node, entering bool) ast.WalkStatus {
 		if !entering {
 			return ast.GoToNext // Don't care about closing the heading section.
 		}
-		t, ok := node.(*ast.Text)
-		if !ok {
-			return ast.GoToNext // Ignore non-text nodes.
+
+		switch node.(type) {
+		case *ast.Text, *ast.Code:
+			text += string(node.AsLeaf().Literal)
 		}
 
-		text += string(t.AsLeaf().Literal)
 		return ast.GoToNext
 	})
 	return text

--- a/testdata/code.md
+++ b/testdata/code.md
@@ -1,0 +1,22 @@
+---
+title: this is a title block
+description: we should ignore it
+---
+
+# Expected TOC
+
+Manually verified by uploading to github.
+
+<!-- toc -->
+- [Expected TOC](#expected-toc)
+- [H1 <code>H1</code> H1](#h1-h1-h1)
+- [H2 <code>H2</code>](#h2-h2)
+<!-- /toc -->
+
+# H1 `H1` H1
+
+filler
+
+# H2 `H2`
+
+filler


### PR DESCRIPTION
Inline code in headings has been silently skipped before this patch.
Now we support those as well as adding a test case about it.

cc @kubernetes-sigs/release-engineering 