### PR TITLE
Remove `LappleApple` from SIG Release leadership team

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -10,6 +10,5 @@ aliases:
     - cpanato
     - jeremyrickard
     - justaugustus
-    - LappleApple
     - puerco
     - saschagrunert


### PR DESCRIPTION
Lauri has stepped back from SIG Release some time ago. This cleanup should reflect the current state of the SIG.

Refers to https://github.com/kubernetes/community/pull/6675, https://github.com/kubernetes/org/pull/3450

cc @cpanato @justaugustus @puerco @jeremyrickard 