### PR TITLE
update golangci-lint, bump go min version to 1.21 and fix lints

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -17,9 +17,7 @@ linters:
     - bodyclose
     - containedctx
     - contextcheck
-    - deadcode
     - decorder
-    - depguard
     - dogsled
     - dupl
     - durationcheck
@@ -50,7 +48,6 @@ linters:
     - gosimple
     - govet
     - grouper
-    - ifshort
     - importas
     - ineffassign
     - maintidx
@@ -71,7 +68,6 @@ linters:
     - rowserrcheck
     - sqlclosecheck
     - staticcheck
-    - structcheck
     - stylecheck
     - tagliatelle
     - tenv
@@ -81,7 +77,6 @@ linters:
     - unconvert
     - unparam
     - unused
-    - varcheck
     - wastedassign
     - whitespace
     - wrapcheck
@@ -182,7 +177,6 @@ linters-settings:
       - hexLiteral
       - httpNoBody
       - ifElseChain
-      - ioutilDeprecated
       - methodExprCall
       - newDeref
       - octalLiteral

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/mdtoc
 
-go 1.18
+go 1.21
 
 require (
 	github.com/gomarkdown/markdown v0.0.0-20220527210340-c82b80a9daf2
@@ -12,5 +12,5 @@ require (
 	github.com/BurntSushi/toml v0.3.1 // indirect
 	github.com/davecgh/go-spew v1.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
+	gopkg.in/yaml.v3 v3.0.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -13,5 +13,6 @@ github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMT
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.0 h1:hjy8E9ON/egN1tAYqKb61G10WtihqetD4sz2H+8nIeA=
+gopkg.in/yaml.v3 v3.0.0/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/hack/verify-golangci-lint.sh
+++ b/hack/verify-golangci-lint.sh
@@ -18,7 +18,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-VERSION=v1.46.2
+VERSION=v1.54.2
 URL_BASE=https://raw.githubusercontent.com/golangci/golangci-lint
 URL=$URL_BASE/$VERSION/install.sh
 

--- a/mdtoc_test.go
+++ b/mdtoc_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package main
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -120,7 +119,7 @@ func TestInplace(t *testing.T) {
 
 			// Create a copy of the test.file to modify.
 			escapedFile := strings.ReplaceAll(test.file, string(filepath.Separator), "_")
-			tmpFile, err := ioutil.TempFile("", escapedFile)
+			tmpFile, err := os.CreateTemp("", escapedFile)
 			require.NoError(t, err, test.file)
 			defer os.Remove(tmpFile.Name())
 			_, err = tmpFile.Write(original)


### PR DESCRIPTION
- update golangci-lint, bump go min version to 1.21 and fix lints

/hold for test-infra job update

/assign @saschagrunert @xmudrii @Verolop 
cc @kubernetes-sigs/release-engineering 