### PR TITLE
revert go.mod to accept minimum go 1.21

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/mdtoc
 
-go 1.22
+go 1.21
 
 require (
 	github.com/gomarkdown/markdown v0.0.0-20240328165702-4d01890c35c0

--- a/mdtoc_test.go
+++ b/mdtoc_test.go
@@ -84,6 +84,7 @@ func testdata(subpath string) string {
 func TestDryRun(t *testing.T) {
 	t.Parallel()
 	for _, test := range testcases {
+		test := test
 		t.Run(test.file, func(t *testing.T) {
 			t.Parallel()
 			opts := utilityOptions{
@@ -110,6 +111,7 @@ func TestDryRun(t *testing.T) {
 func TestInplace(t *testing.T) {
 	t.Parallel()
 	for _, test := range testcases {
+		test := test
 		t.Run(test.file, func(t *testing.T) {
 			t.Parallel()
 			original, err := os.ReadFile(test.file)
@@ -155,6 +157,7 @@ func TestInplace(t *testing.T) {
 func TestOutput(t *testing.T) {
 	t.Parallel()
 	for _, test := range testcases {
+		test := test
 		// Ignore the invalid cases, they're only for inplace tests.
 		if !test.validTOCTags {
 			continue


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup


#### What this PR does / why we need it:

- revert go.mod to accept minimum go 1.21
/assign @puerco @saschagrunert @xmudrii 



#### Which issue(s) this PR fixes:


None


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires
additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
